### PR TITLE
Enable project and workspace creation

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -138,7 +138,8 @@ class ConsoleGenerator extends Generator {
     const projects = (await this.sdkClient.getProjectsForOrg(orgId)).body
     spinner.stop()
 
-    const projectsList = projects.map(item => item.title)
+    // show projects by title and reverse order to show latest first
+    const projectsList = projects.map(item => item.title).reverse()
     const promptFunc = this.allowCreate ? this.customPrompt.promptSelectOrCreate : this.customPrompt.promptSelect
     const projectResult = await promptFunc('Project', projectsList)
     let project = projects.find(item => item.title === projectResult)

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -72,7 +72,7 @@ class ConsoleGenerator extends Generator {
 
   async initializing () {
     this.env.adapter.promptModule.registerPrompt('autocomplete',
-      require('inquirer-autocomplete-prompt')
+      require('../../lib/inquirer-autocomplete-with-escape-prompt')
     )
 
     const env = this.options[Option.ENV]
@@ -140,11 +140,9 @@ class ConsoleGenerator extends Generator {
     if (!project) { // create new
       console.log('Enter Project details:')
       const name = await this.customPrompt.promptInput('Name', {
-        default: projectResult,
         validate: validateName
       })
       const title = await this.customPrompt.promptInput('Title', {
-        default: projectResult,
         validate: validateTitle
       })
       const description = await this.customPrompt.promptInput('Description', { default: '' })

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -18,8 +18,7 @@ const {
   validateProjectTitle,
   validateProjectDescription,
   validateWorkspaceName,
-  validateWorkspaceTitle,
-  validateWorkspaceDescription
+  validateWorkspaceTitle
 } = require('../../lib/validate')
 
 /*
@@ -159,22 +158,23 @@ class ConsoleGenerator extends Generator {
 
       spinner.start()
 
+      // create the projectId
       spinner.text = 'Creating Project...'
       const createdProject = (await this.sdkClient.createProject(orgId, { name, title, description, type: this.projectType })).body
-
-      // get complete record
       const projectId = createdProject.projectId
-      spinner.text = 'Getting new Project...'
-      project = (await this.sdkClient.getProject(orgId, projectId)).body
 
       // create the missing stage workspace
       spinner.text = 'Creating Stage Workspace...'
-      await this.sdkClient.createWorkspace(orgId, project.id, { name: 'Stage' })
+      await this.sdkClient.createWorkspace(orgId, projectId, { name: 'Stage' })
 
       // enable runtime on the Production and Stage workspace
       spinner.text = 'Enabling Adobe I/O Runtime...'
       const workspaces = (await (this.sdkClient.getWorkspacesForProject(orgId, projectId))).body
       await Promise.all(workspaces.map(w => this.sdkClient.createRuntimeNamespace(orgId, projectId, w.id)))
+
+      // get complete record
+      spinner.text = 'Getting new Project...'
+      project = (await this.sdkClient.getProject(orgId, projectId)).body
 
       spinner.stop()
     }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -138,8 +138,8 @@ class ConsoleGenerator extends Generator {
     const projects = (await this.sdkClient.getProjectsForOrg(orgId)).body
     spinner.stop()
 
-    // show projects by title and reverse order to show latest first
-    const projectsList = projects.map(item => item.title).reverse()
+    // show projects by title and reverse order to show latest first, note reverse is in place, let's make sure project is not modified
+    const projectsList = [...projects.map(item => item.title)].reverse()
     const promptFunc = this.allowCreate ? this.customPrompt.promptSelectOrCreate : this.customPrompt.promptSelect
     const projectResult = await promptFunc('Project', projectsList)
     let project = projects.find(item => item.title === projectResult)

--- a/lib/inquirer-autocomplete-with-escape-prompt.js
+++ b/lib/inquirer-autocomplete-with-escape-prompt.js
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const AutocompletePrompt = require('inquirer-autocomplete-prompt')
+const { EOL } = require('os')
+
+/**
+ * This is an inquirer plugin extending inquirer-autocomplete-prompt with an escape symbol.
+ *
+ * @class AutocompleteWithEscapePrompt
+ * @augments {AutocompletePrompt}
+ */
+class AutocompleteWithEscapePrompt extends AutocompletePrompt {
+  onKeypress (e) {
+    // if the escape symbol is pressed, exit the prompt and return the symbol
+    if (this.opt.escapeSymbol && e.value === this.opt.escapeSymbol) {
+      this.answer = this.opt.escapeSymbol
+      this.status = 'answered'
+      this.rl.line = EOL
+      this.render()
+      this.screen.done()
+      this.done(this.answer)
+    }
+    // otherwise continue as always
+    super.onKeypress(e)
+  }
+}
+
+module.exports = AutocompleteWithEscapePrompt

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -24,7 +24,7 @@ function promptSelectOrCreate (generator) {
         name,
         data,
         {
-          message: `Select ${name} or create new [tab before selection] -`,
+          message: `Select or create ${name} [tab before select]:`,
           suggestOnly: true,
           validate: validateName
         }
@@ -36,6 +36,48 @@ function promptSelectOrCreate (generator) {
 
       if (await promptConfirm(generator)(`${name} '${res}'`)) {
         return res
+      }
+    }
+  }
+}
+
+/** @private */
+function promptSelect (generator) {
+  return async function (name, data, moreOptions = {}) {
+    const choice = await generator.prompt([
+      {
+        type: 'autocomplete',
+        name: 'res',
+        message: `Select ${name}:`,
+        source: createSourceForPromptSelect(data),
+        ...moreOptions
+      }
+    ])
+    return choice.res
+  }
+}
+
+/** @private */
+function createSourceForPromptSelect (data) {
+  return async function (answersSoFar, input = '') {
+    return fuzzy.filter(input, data).map(item => item.string)
+  }
+}
+
+/** @private */
+function promptCreation (generator) {
+  return async function (name) {
+    while (true) {
+      const create = await generator.prompt([
+        {
+          type: 'input',
+          name: 'res',
+          message: `Create a new ${name}:`,
+          validate: validateName
+        }
+      ])
+      if (await promptConfirm(generator)(`${name} '${create.res}'`)) {
+        return create.res
       } else {
         return null
       }
@@ -56,50 +98,6 @@ function promptMultiSelect (generator) {
       }
     ])
     return choice.res
-  }
-}
-
-/** @private */
-function createSourceForPromptSelect (data) {
-  return async function (answersSoFar, input = '') {
-    return fuzzy.filter(input, data).map(item => item.string)
-  }
-}
-
-/** @private */
-function promptSelect (generator) {
-  return async function (name, data, moreOptions = {}) {
-    const choice = await generator.prompt([
-      {
-        type: 'autocomplete',
-        name: 'res',
-        message: `Select ${name}`,
-        source: createSourceForPromptSelect(data),
-        ...moreOptions
-      }
-    ])
-    return choice.res
-  }
-}
-
-/** @private */
-function promptCreation (generator) {
-  return async function (name) {
-    while (true) {
-      const create = await generator.prompt([
-        {
-          type: 'input',
-          name: 'res',
-          message: `Create a new ${name}, input -`,
-          validate: validateName
-        }
-      ])
-      if (await promptConfirm(generator)(`${name} '${create.res}'`)) {
-        return create.res
-      } else {
-        return null
-      }
-    }
   }
 }
 

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -9,34 +9,43 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { validateName } = require('./validate')
+const { validateName, validateTitle } = require('./validate')
 const fuzzy = require('fuzzy')
 
 /** @private */
 function promptSelectOrCreate (generator) {
   return async function (name, data = []) {
     if (data.length <= 0) {
-      return promptCreation(generator)(name)
+      console.log(`There are no ${name}s in here, let's create a new one.`)
+      return null
     }
 
+    const escapeSymbol = '+'
     while (true) {
       const res = await promptSelect(generator)(
         name,
         data,
         {
-          message: `Select or create ${name} [tab before select]:`,
-          suggestOnly: true,
-          validate: validateName
+          message: `Select a ${name}, or press + to create new:`,
+          escapeSymbol
         }
       )
 
-      if (data.includes(res)) {
+      if (res !== escapeSymbol) {
+        // return existing entity
         return res
       }
 
-      if (await promptConfirm(generator)(`${name} '${res}'`)) {
-        return res
+      // confirmed creation ?
+      const confirm = await generator.prompt([{
+        type: 'confirm',
+        name: 'res',
+        message: `  > do you wish to create a new ${name}?`
+      }])
+      if (confirm.res) {
+        return null
       }
+      // continue loop
     }
   }
 }
@@ -65,27 +74,6 @@ function createSourceForPromptSelect (data) {
 }
 
 /** @private */
-function promptCreation (generator) {
-  return async function (name) {
-    while (true) {
-      const create = await generator.prompt([
-        {
-          type: 'input',
-          name: 'res',
-          message: `Create a new ${name}:`,
-          validate: validateName
-        }
-      ])
-      if (await promptConfirm(generator)(`${name} '${create.res}'`)) {
-        return create.res
-      } else {
-        return null
-      }
-    }
-  }
-}
-
-/** @private */
 function promptMultiSelect (generator) {
   return async function (message, data, moreOptions = {}) {
     const choice = await generator.prompt([
@@ -98,18 +86,6 @@ function promptMultiSelect (generator) {
       }
     ])
     return choice.res
-  }
-}
-
-/** @private */
-function promptConfirm (generator) {
-  return async function (what) {
-    const confirm = await generator.prompt([{
-      type: 'confirm',
-      name: 'res',
-      message: `  > confirm creation of ${what}?`
-    }])
-    return confirm.res
   }
 }
 
@@ -127,8 +103,6 @@ function promptInput (generator) {
 }
 
 module.exports = (generator) => ({
-  promptConfirm: promptConfirm(generator),
-  promptCreation: promptCreation(generator),
   promptSelect: promptSelect(generator),
   createSourceForPromptSelect,
   promptSelectOrCreate: promptSelectOrCreate(generator),

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -8,8 +8,6 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
-const { validateName, validateTitle } = require('./validate')
 const fuzzy = require('fuzzy')
 
 /** @private */

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -12,11 +12,8 @@ governing permissions and limitations under the License.
 /**
  * @private
  */
-function createValidator (name, regex, allowEmpty) {
+function createValidator (name, regex) {
   return function (input) {
-    if (allowEmpty && input === '') {
-      return true
-    }
     return regex.test(input) || `'${input}' is not a valid ${name}, it must match ${regex.toString()}`
   }
 }
@@ -24,10 +21,10 @@ function createValidator (name, regex, allowEmpty) {
 module.exports = {
   // project input validators
   validateProjectName: createValidator('Project name', /^[a-zA-Z0-9]{1,20}$/),
-  validateProjectTitle: createValidator('Project title', /^(?=\S).{1,45}(?<=\S)$/),
-  validateProjectDescription: createValidator('Project description', /^(?=\S).{1,1000}(?<=\S)$/, true),
+  validateProjectTitle: createValidator('Project title', /^[\sA-Za-z0-9\u00C0-\u00D6\u00D8-\u00f6\u00f8-\u00ff]{1,45}$/),
+  validateProjectDescription: createValidator('Project description', /^.{0,1000}$/), // can be empty
   // workspace input validators
   validateWorkspaceName: createValidator('Workspace name', /^[a-zA-Z0-9]{1,20}$/),
-  validateWorkspaceTitle: createValidator('Workspace title', /^(?=\S).{1,45}(?<=\S)$/, true)
-  // validateWorkspaceDescription: createValidator('Workspace description', /^(?=\S).{1,500}(?<=\S)$/, true)
+  validateWorkspaceTitle: createValidator('Workspace title', /^[\sA-Za-z0-9\u00C0-\u00D6\u00D8-\u00f6\u00f8-\u00ff]{0,45}$/) // can be empty
+  // validateWorkspaceDescription: createValidator('Workspace description', /^(?=\S).{0,500}(?<=\S)$/)
 }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -9,19 +9,25 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-/** @private */
-function validateName (input) {
-  const valid = /^[a-zA-Z0-9]{1,20}$/
-  return valid.test(input) || `'${input}' is not a valid name for creation, the name must match /^[a-zA-Z0-9]{1,20}$/`
-}
-
-/** @private */
-function validateTitle (input) {
-  const valid = /^[\sA-Za-z0-9\u00C0-\u00D6\u00D8-\u00f6\u00f8-\u00ff]{1,45}$/
-  return valid.test(input) || `'${input}' is not a valid title for creation, the name must match /^[\\sA-Za-z0-9\u00C0-\u00D6\u00D8-\u00f6\u00f8-\u00ff]{1,45}$/`
+/**
+ * @private
+ */
+function createValidator (name, regex, allowEmpty) {
+  return function (input) {
+    if (allowEmpty && input === '') {
+      return true
+    }
+    return regex.test(input) || `'${input}' is not a valid ${name}, it must match ${regex.toString()}`
+  }
 }
 
 module.exports = {
-  validateName,
-  validateTitle
+  // project input validators
+  validateProjectName: createValidator('Project name', /^[a-zA-Z0-9]{1,20}$/),
+  validateProjectTitle: createValidator('Project title', /^(?=\S).{1,45}(?<=\S)$/),
+  validateProjectDescription: createValidator('Project description', /^(?=\S).{1,1000}(?<=\S)$/, true),
+  // workspace input validators
+  validateWorkspaceName: createValidator('Workspace name', /^[a-zA-Z0-9]{1,20}$/),
+  validateWorkspaceTitle: createValidator('Workspace title', /^(?=\S).{1,45}(?<=\S)$/, true)
+  // validateWorkspaceDescription: createValidator('Workspace description', /^(?=\S).{1,500}(?<=\S)$/, true)
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "yeoman-test": "^2.6.0"
   },
   "dependencies": {
-    "@adobe/aio-lib-console": "^1.2.0",
+    "@adobe/aio-lib-console": "^2.0.0",
     "fuzzy": "^0.1.3",
     "inquirer-autocomplete-prompt": "^1.0.2",
     "ora": "^4.0.4",

--- a/test/lib/inquirer-autocomplete-with-escape-prompt.test.js
+++ b/test/lib/inquirer-autocomplete-with-escape-prompt.test.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+/* eslint-disable no-proto */
+jest.mock('inquirer-autocomplete-prompt')
+
+const AutocompleteWithEscapePrompt = require('../../lib/inquirer-autocomplete-with-escape-prompt')
+
+let autocompleteWithEscapePrompt
+let superKeypressMock
+beforeEach(() => {
+  // somehow the super mock is replacing defined methods of the child class, so we retrieve the child in __proto__
+  autocompleteWithEscapePrompt = (new AutocompleteWithEscapePrompt()).__proto__
+  // let's assign what we need from the mocked super class
+  Object.assign(autocompleteWithEscapePrompt, {
+    rl: {},
+    done: jest.fn(),
+    render: () => {},
+    screen: { done: () => {} },
+    opt: {}
+  })
+  superKeypressMock = autocompleteWithEscapePrompt.__proto__.onKeypress
+  superKeypressMock.mockClear()
+})
+
+describe('AutocompleteWithEscapePrompt.onKeyPress', () => {
+  test('pressed non-escape char with opt.escapeSymbol not set', () => {
+    const input = { value: 'a' }
+    autocompleteWithEscapePrompt.onKeypress(input)
+
+    expect(superKeypressMock).toHaveBeenCalledWith(input)
+    expect(autocompleteWithEscapePrompt.done).not.toHaveBeenCalled()
+  })
+
+  test('pressed non-escape char with opt.escapeSymbol set', () => {
+    const input = { value: 'a' }
+    autocompleteWithEscapePrompt.opt.escapeSymbol = '+'
+    autocompleteWithEscapePrompt.onKeypress(input)
+
+    expect(superKeypressMock).toHaveBeenCalledWith(input)
+    expect(autocompleteWithEscapePrompt.done).not.toHaveBeenCalled()
+  })
+  test('pressed escape char', () => {
+    const input = { value: '+' }
+    autocompleteWithEscapePrompt.opt.escapeSymbol = '+'
+    autocompleteWithEscapePrompt.done = jest.fn()
+
+    autocompleteWithEscapePrompt.onKeypress(input)
+
+    expect(autocompleteWithEscapePrompt.done).toHaveBeenCalledWith('+')
+  })
+})

--- a/test/lib/prompt.test.js
+++ b/test/lib/prompt.test.js
@@ -34,39 +34,11 @@ function createMockGenerator (returnValue) {
 
 test('exports', () => {
   const genPrompt = prompt({})
-  expect(typeof genPrompt.promptConfirm).toEqual('function')
-  expect(typeof genPrompt.promptCreation).toEqual('function')
   expect(typeof genPrompt.promptSelect).toEqual('function')
   expect(typeof genPrompt.promptSelectOrCreate).toEqual('function')
   expect(typeof genPrompt.promptInput).toEqual('function')
   expect(typeof genPrompt.promptMultiSelect).toEqual('function')
   expect(typeof genPrompt.createSourceForPromptSelect).toEqual('function')
-})
-
-test('promptConfirm', async () => {
-  const mockReturnValue = true
-  const mockGenerator = createMockGenerator(mockReturnValue)
-
-  const genPrompt = prompt(mockGenerator)
-  await expect(genPrompt.promptConfirm('what')).resolves.toEqual(mockReturnValue)
-})
-
-test('promptCreation', async () => {
-  let mockReturnValues, mockGenerator, genPrompt
-
-  // success, confirm true
-  mockReturnValues = ['newProject', true]
-  mockGenerator = createMockGenerator(mockReturnValues)
-
-  genPrompt = prompt(mockGenerator)
-  await expect(genPrompt.promptCreation('what')).resolves.toEqual(mockReturnValues[0])
-
-  // success, confirm false (else path)
-  mockReturnValues = ['newProject', false]
-  mockGenerator = createMockGenerator(mockReturnValues)
-
-  genPrompt = prompt(mockGenerator)
-  await expect(genPrompt.promptCreation('what')).resolves.toEqual(null)
 })
 
 test('promptSelect', async () => {
@@ -85,23 +57,20 @@ test('promptSelectOrCreate', async () => {
   genPrompt = prompt(mockGenerator)
   await expect(genPrompt.promptSelectOrCreate('what', [mockReturnValue, 'anotherProject'])).resolves.toEqual(mockReturnValue)
 
-  // coverage, data empty, nothing to select from (promptCreation)
-  mockReturnValue = ['newProject', true]
-  mockGenerator = createMockGenerator(mockReturnValue)
-  genPrompt = prompt(mockGenerator)
-  await expect(genPrompt.promptSelectOrCreate('what')).resolves.toEqual(mockReturnValue[0])
+  // data empty, nothing to select from (console.log and returns null for creation)
+  await expect(genPrompt.promptSelectOrCreate('what')).resolves.toEqual(null)
 
-  // coverage, selection not in data set, new item input by user
-  mockReturnValue = ['newProject', true]
-  mockGenerator = createMockGenerator(mockReturnValue)
-  genPrompt = prompt(mockGenerator)
-  await expect(genPrompt.promptSelectOrCreate('what', ['projectA', 'projectB'])).resolves.toEqual(mockReturnValue[0])
-
-  // coverage, selection not in data set, new item input by user. (else path, cancel confirmation)
-  mockReturnValue = ['newProject', false]
+  // ask for creation by user, no confirmation then confirm creation
+  mockReturnValue = ['+', false, '+', true]
   mockGenerator = createMockGenerator(mockReturnValue)
   genPrompt = prompt(mockGenerator)
   await expect(genPrompt.promptSelectOrCreate('what', ['projectA', 'projectB'])).resolves.toEqual(null)
+
+  // ask for creation by user, no confirmation then select existing project
+  mockReturnValue = ['+', false, 'existingProject']
+  mockGenerator = createMockGenerator(mockReturnValue)
+  genPrompt = prompt(mockGenerator)
+  await expect(genPrompt.promptSelectOrCreate('what', ['projectA', 'projectB'])).resolves.toEqual('existingProject')
 })
 
 test('promptInput', async () => {

--- a/test/lib/validate.test.js
+++ b/test/lib/validate.test.js
@@ -9,69 +9,164 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { validateName, validateTitle } = require('../../lib/validate')
+const v = require('../../lib/validate')
 
-test('validateName success', () => {
-  let name
+describe('validateProjectName', () => {
+  let input
+  test('success', () => {
+    input = 'aBcD1234' // mixed case
+    expect(v.validateProjectName(input)).toBe(true)
 
-  name = 'aBcD1234' // mixed case
-  expect(validateName(name)).toBe(true)
+    input = '12345678901234567890' // 20 char input
+    expect(v.validateProjectName(input)).toBe(true)
 
-  name = '12345678901234567890' // 20 char name
-  expect(validateName(name)).toBe(true)
+    input = 'a' // 1 char input
+    expect(v.validateProjectName(input)).toBe(true)
+  })
+  test('failure', () => {
+    // the error string is returned if the input is invalid (bool true if valid)
 
-  name = 'a' // 1 char name
-  expect(validateName(name)).toBe(true)
+    input = 'aBcD^&1234' // input with special char
+    expect(typeof v.validateProjectName(input)).toEqual('string')
+
+    input = 'aBCd 123' // input with spaces
+    expect(typeof v.validateProjectName(input)).toEqual('string')
+
+    input = 'aBCd-123' // input with hyphen
+    expect(typeof v.validateProjectName(input)).toEqual('string')
+
+    input = '123456789012345678901' // 21 char input
+    expect(typeof v.validateProjectName(input)).toEqual('string')
+
+    input = '' // 0 empty
+    expect(typeof v.validateProjectName(input)).toEqual('string')
+  })
 })
 
-test('validateName failure', () => {
-  let name
+describe('validateWorkspaceName', () => {
+  let input
+  test('success', () => {
+    input = 'aBcD1234' // mixed case
+    expect(v.validateWorkspaceName(input)).toBe(true)
 
-  // the error string is returned if the name is invalid (bool true if valid)
+    input = '12345678901234567890' // 20 char input
+    expect(v.validateWorkspaceName(input)).toBe(true)
 
-  name = 'aBcD^&1234' // name with special char
-  expect(typeof validateName(name)).toEqual('string')
+    input = 'a' // 1 char input
+    expect(v.validateWorkspaceName(input)).toBe(true)
+  })
+  test('failure', () => {
+    // the error string is returned if the input is invalid (bool true if valid)
 
-  name = 'aBCd 123' // name with spaces
-  expect(typeof validateName(name)).toEqual('string')
+    input = 'aBcD^&1234' // input with special char
+    expect(typeof v.validateWorkspaceName(input)).toEqual('string')
 
-  name = 'aBCd-123' // name with hyphen
-  expect(typeof validateName(name)).toEqual('string')
+    input = 'aBCd 123' // input with spaces
+    expect(typeof v.validateWorkspaceName(input)).toEqual('string')
 
-  name = '123456789012345678901' // 21 char name
-  expect(typeof validateName(name)).toEqual('string')
+    input = 'aBCd-123' // input with hyphen
+    expect(typeof v.validateWorkspaceName(input)).toEqual('string')
 
-  name = '' // 0 char name
-  expect(typeof validateName(name)).toEqual('string')
+    input = '123456789012345678901' // 21 char input
+    expect(typeof v.validateWorkspaceName(input)).toEqual('string')
+
+    input = '' // 0 empty
+    expect(typeof v.validateWorkspaceName(input)).toEqual('string')
+  })
 })
 
-test('validateTitle success', () => {
-  let name
+describe('validateProjectTitle', () => {
+  let input
+  test('success', () => {
+    input = 'aBcD1234' // mixed case
+    expect(v.validateProjectTitle(input)).toBe(true)
 
-  name = 'aBcD1234' // mixed case
-  expect(validateTitle(name)).toBe(true)
+    input = 'aBcD 1234 xyZ' // mixed case with spaces
+    expect(v.validateProjectTitle(input)).toBe(true)
 
-  name = 'aBcD 1234 xyZ' // mixed case with spaces
-  expect(validateTitle(name)).toBe(true)
+    input = 'üøäî' // special alphabetic chars
+    expect(v.validateProjectTitle(input)).toBe(true)
 
-  name = '123456789012345678901234567890123456789012345' // 45 char name
-  expect(validateTitle(name)).toBe(true)
+    input = '123456789012345678901234567890123456789012345' // 45 char input
+    expect(v.validateProjectTitle(input)).toBe(true)
 
-  name = 'a' // 1 char name
-  expect(validateTitle(name)).toBe(true)
+    input = 'a' // 1 char input
+    expect(v.validateProjectTitle(input)).toBe(true)
+  })
+
+  test('failure', () => {
+    // the error string is returned if the input is invalid (bool true if valid)
+
+    input = '-' // input is a special char
+    expect(typeof v.validateProjectTitle(input)).toEqual('string')
+
+    input = '1234567890123456789012345678901234567890123456' // 46 char input
+    expect(typeof v.validateProjectTitle(input)).toEqual('string')
+
+    input = '' // 0 char input
+    expect(typeof v.validateProjectTitle(input)).toEqual('string')
+  })
 })
 
-test('validateTitle failure', () => {
-  let name
+describe('validateWorkspaceTitle', () => {
+  let input
+  test('success', () => {
+    input = 'aBcD1234' // mixed case
+    expect(v.validateWorkspaceTitle(input)).toBe(true)
 
-  // the error string is returned if the name is invalid (bool true if valid)
+    input = 'aBcD 1234 xyZ' // mixed case with spaces
+    expect(v.validateWorkspaceTitle(input)).toBe(true)
 
-  name = '-' // name is a special char
-  expect(typeof validateTitle(name)).toEqual('string')
+    input = 'üøäî' // special alphabetic chars
+    expect(v.validateProjectTitle(input)).toBe(true)
 
-  name = '1234567890123456789012345678901234567890123456' // 46 char name
-  expect(typeof validateTitle(name)).toEqual('string')
+    input = '123456789012345678901234567890123456789012345' // 45 char input
+    expect(v.validateWorkspaceTitle(input)).toBe(true)
 
-  name = '' // 0 char name
-  expect(typeof validateTitle(name)).toEqual('string')
+    input = 'a' // 1 char input
+    expect(v.validateWorkspaceTitle(input)).toBe(true)
+
+    input = '' // 0 char input
+    expect(v.validateWorkspaceTitle(input)).toBe(true)
+  })
+
+  test('failure', () => {
+    // the error string is returned if the input is invalid (bool true if valid)
+
+    input = '-' // input is a special char
+    expect(typeof v.validateWorkspaceTitle(input)).toEqual('string')
+
+    input = '1234567890123456789012345678901234567890123456' // 46 char input
+    expect(typeof v.validateWorkspaceTitle(input)).toEqual('string')
+  })
+})
+
+describe('validateProjectDescription', () => {
+  let input
+  test('success', () => {
+    input = 'aBcD1234' // mixed case
+    expect(v.validateProjectDescription(input)).toBe(true)
+
+    input = 'aBcD 1234 xyZ' // mixed case with spaces
+    expect(v.validateProjectDescription(input)).toBe(true)
+
+    input = 'aBcD 1234 xyZ üîø &!)*(#&$@{}:-' // mixed case with spaces and symbols
+    expect(v.validateProjectDescription(input)).toBe(true)
+
+    input = '1234567890'.repeat(100) // 1000 char input
+    expect(v.validateProjectDescription(input)).toBe(true)
+
+    input = 'a' // 1 char input
+    expect(v.validateProjectDescription(input)).toBe(true)
+
+    input = '' // 0 char input
+    expect(v.validateProjectDescription(input)).toBe(true)
+  })
+
+  test('failure', () => {
+    // the error string is returned if the input is invalid (bool true if valid)
+
+    input = '1234567890'.repeat(100) + '1' // 1001 char input
+    expect(typeof v.validateProjectDescription(input)).toEqual('string')
+  })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- leverage existing code to create project and workspaces on init
- add Stage workspace on project creation
- enable runtime on every newly created worskpace
- extend autocomplete plugin to support an escape key for creation ('+')

Relates to: https://github.com/adobe/aio-cli-plugin-app/pull/319
Depends on: https://github.com/adobe/aio-lib-console/pull/15

NEEDS A RELEASE IN AIO-LIB-CONSOLE + Major dep bump before merging this

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
